### PR TITLE
위변조 방지 토큰 구현을 변경한다

### DIFF
--- a/document/ddl.sql
+++ b/document/ddl.sql
@@ -34,11 +34,14 @@ CREATE INDEX idx_email ON user (email);
 
 CREATE TABLE verification_token
 (
-    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
-    type       ENUM ('MOBILE') NOT NULL DEFAULT 'MOBILE',
-    token      VARCHAR(64)     NOT NULL,
-    created_at DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    type            ENUM ('MOBILE') NOT NULL DEFAULT 'MOBILE',
+    token           VARCHAR(64)     NOT NULL,
+    created_at      DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    verification_id BIGINT,
+    INDEX idx_token(token),
+    INDEX idx_verification_id (verification_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8;
 

--- a/src/main/java/ms/study/kurly/common/exception/KurlyExceptionHandler.java
+++ b/src/main/java/ms/study/kurly/common/exception/KurlyExceptionHandler.java
@@ -21,7 +21,7 @@ public class KurlyExceptionHandler {
 
     private final ObjectMapper objectMapper;
 
-    @ExceptionHandler(Exception.class)
+    @ExceptionHandler(KurlyException.class)
     public ResponseEntity<Response<Void>> handleKurlyException(KurlyException e) throws JsonProcessingException {
 
         String data = objectMapper.writeValueAsString(e.getData());

--- a/src/main/java/ms/study/kurly/domain/terms/TermsAgreement.java
+++ b/src/main/java/ms/study/kurly/domain/terms/TermsAgreement.java
@@ -31,6 +31,7 @@ public class TermsAgreement {
     private String email;
 
     @Column(nullable = false)
+    @Setter(AccessLevel.PUBLIC)
     private Boolean agreed;
 
     @CreatedDate

--- a/src/main/java/ms/study/kurly/domain/terms/TermsAgreementController.java
+++ b/src/main/java/ms/study/kurly/domain/terms/TermsAgreementController.java
@@ -14,7 +14,7 @@ public class TermsAgreementController {
     private final TermsAgreementService service;
 
     @PostMapping("/terms/agreement")
-    public void agreement(@Valid @RequestBody TermsAgreementRequest request) throws Exception {
+    public void agreement(@Valid @RequestBody TermsAgreementRequest request) {
 
         service.agreement(request);
     }

--- a/src/main/java/ms/study/kurly/domain/terms/dto/TermsAgreementRequest.java
+++ b/src/main/java/ms/study/kurly/domain/terms/dto/TermsAgreementRequest.java
@@ -13,7 +13,6 @@ import lombok.*;
 public class TermsAgreementRequest {
 
     @Schema(description = "이용 약관 동의 목록")
-    @NotBlank
     private Agreement[] agreements;
 
     @Schema(description = "이메일 주소", defaultValue = "aa@bb.cc")
@@ -21,7 +20,6 @@ public class TermsAgreementRequest {
     private String email;
 
     @Schema(description = "휴대폰 인증 응답으로 전달받은 위변조 방지 토큰")
-    @NotBlank
     private String mobileVerificationToken;
 
     @Schema(description = "이용 약관 동의 내용")

--- a/src/main/java/ms/study/kurly/domain/verification/MobileVerificationController.java
+++ b/src/main/java/ms/study/kurly/domain/verification/MobileVerificationController.java
@@ -26,7 +26,7 @@ public class MobileVerificationController {
     }
 
     @PostMapping("/verification/mobile-verification-code/verify")
-    public Response<MobileCodeVerifyResponse> verifyMobileVerificationCodeRequest(@Valid @RequestBody MobileCodeVerifyRequest request) throws Exception {
+    public Response<MobileCodeVerifyResponse> verifyMobileVerificationCodeRequest(@Valid @RequestBody MobileCodeVerifyRequest request) {
 
         return mobileVerificationService.verifyMobileVerificationCode(request);
     }

--- a/src/main/java/ms/study/kurly/domain/verification/MobileVerificationService.java
+++ b/src/main/java/ms/study/kurly/domain/verification/MobileVerificationService.java
@@ -45,7 +45,7 @@ public class MobileVerificationService {
         mobileVerificationRepository.save(mobileVerification);
     }
 
-    public Response<MobileCodeVerifyResponse> verifyMobileVerificationCode(MobileCodeVerifyRequest dto) throws Exception {
+    public Response<MobileCodeVerifyResponse> verifyMobileVerificationCode(MobileCodeVerifyRequest dto) {
 
         MobileVerification verification = mobileVerificationRepository
                 .findFirstByMobileNumberOrderByCreatedAtDesc(dto.getMobileNumber())
@@ -70,15 +70,15 @@ public class MobileVerificationService {
             throw new KurlyException(error, data);
         }
 
-        VerificationToken token = verificationTokenService.generate(VerificationTokenRequest.builder()
+        VerificationToken verificationToken = verificationTokenService.generate(VerificationTokenRequest.builder()
                 .verificationId(verification.getId())
                 .type(VerificationToken.Type.MOBILE)
                 .build());
 
-        verification.setVerificationToken(token);
+        verification.setVerificationToken(verificationToken);
 
         return Response.<MobileCodeVerifyResponse>builder()
-                .data(new MobileCodeVerifyResponse(token.getToken()))
+                .data(new MobileCodeVerifyResponse(verificationToken.getToken()))
                 .build();
     }
 }

--- a/src/main/java/ms/study/kurly/domain/verification/VerificationTokenRepository.java
+++ b/src/main/java/ms/study/kurly/domain/verification/VerificationTokenRepository.java
@@ -2,5 +2,9 @@ package ms.study.kurly.domain.verification;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface VerificationTokenRepository extends JpaRepository<VerificationToken, Long> {
+
+    Optional<VerificationToken> findByToken(String token);
 }

--- a/src/main/java/ms/study/kurly/domain/verification/VerificationTokenService.java
+++ b/src/main/java/ms/study/kurly/domain/verification/VerificationTokenService.java
@@ -1,10 +1,11 @@
 package ms.study.kurly.domain.verification;
 
 import lombok.RequiredArgsConstructor;
-import ms.study.kurly.common.encryption.EncryptionUtils;
 import ms.study.kurly.domain.verification.dto.VerificationTokenRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @Transactional
@@ -13,13 +14,16 @@ public class VerificationTokenService {
 
     private final VerificationTokenRepository verificationTokenRepository;
 
-    public VerificationToken generate(VerificationTokenRequest request) throws Exception {
+    public VerificationToken generate(VerificationTokenRequest request) {
 
-        String token = EncryptionUtils.encrypt(request.getVerificationId());
+        String token = UUID.randomUUID().toString();
 
-        return VerificationToken.builder()
+        VerificationToken verificationToken = VerificationToken.builder()
                 .type(request.getType())
                 .token(token)
+                .verificationId(request.getVerificationId())
                 .build();
+
+        return verificationTokenRepository.save(verificationToken);
     }
 }


### PR DESCRIPTION
기존 방식은 특정 테이블의 ID를 암호화하기 때문에 ID가 생성되는 규칙을 특정할 수 있어 테이블 구 조를 변경하고 UUID를 생성하여 관리하는 방식으로 변경한다.
이메일 주소 기준으로 약관 동의 내용이 이미 존재한다면 기존 데이터를 업데이트 하도록 추가한다.